### PR TITLE
Fix Jekyll build: exclude CLAUDE.md and remove deprecated gems config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,10 +9,6 @@ author:
   name:             Diego Porres
   url:              https://blog.diegoporres.com
 
-# Gems
-gems:
-  - jekyll-paginate
-
 #Others
 markdown:           kramdown
 theme:              jekyll-theme-cayman
@@ -34,6 +30,7 @@ plugins:
 # Exclude from processing
 exclude:
   - README.md
+  - CLAUDE.md
   - Gemfile
   - Gemfile.lock
   - node_modules


### PR DESCRIPTION
- Added CLAUDE.md to exclude list (contains example code with non-existent includes)
- Removed deprecated 'gems:' section (now using 'plugins:' instead)
- Fixes GitHub Pages build error