### PR TITLE
Fix: Load style.css and add home link

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -5,6 +5,7 @@
   <meta name="theme-color" content="#157878">
   <link rel="stylesheet" href="{{ site.baseurl }}/css/normalize.css">
   <link rel="stylesheet" href="{{ site.baseurl }}/css/cayman.css">
+  <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/style.css">
 
    <!-- Global site tag (gtag.js) - Google Analytics -->
  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-117842398-1"></script>

--- a/_includes/page-header.html
+++ b/_includes/page-header.html
@@ -1,5 +1,5 @@
 <section class="page-header">
-  <h1 class="project-name">{{ site.title }}</h1>
+  <h1 class="project-name"><a href="{{ site.baseurl }}/" style="color: inherit; text-decoration: none;">{{ site.title }}</a></h1>
   <h2 class="project-tagline">{{ site.tagline }}</h2>
   <a href="https://github.com/PDillis/pdillis.github.io/blob/master/_data/Resume_Academic_DiegoPorres.pdf" class="btn" target="_blank">📄 CV/Resume</a>
   <a href="https://github.com/PDillis/" class="btn" target="_blank">💻 GitHub</a>


### PR DESCRIPTION
CRITICAL FIX:
- Added missing link to assets/css/style.css in head.html
- This CSS file contains ALL custom styles (CSS variables, dark mode, copy buttons)
- Without it, dark mode doesn't work and copy buttons are broken

HOME NAVIGATION:
- Made blog title (Diego's blog) clickable to return home
- Uses site.baseurl for proper routing
- Inherits color and removes underline for clean look

This should fix both the dark mode toggle and copy button issues!